### PR TITLE
feat(sb-1135): clone new sprucebot-skills-kit workspace for platform …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 config/local.*
 package-lock.json
+yarn-error.log
 
 # ***** BEGIN INTELLIJ *****
 # User-specific stuff:

--- a/actions/platform/index.js
+++ b/actions/platform/index.js
@@ -30,7 +30,10 @@ function setup(argv) {
 
 	program
 		.command('install [path]')
-		.option('-p --platform [platform]', 'all|web|api|relay')
+		.option(
+			'-p --platform [platform]',
+			'all|web|api|relay|sprucebot-skills-kit'
+		)
 		.option('-u --username [gitUser]', 'Your github username')
 		.option(
 			'-b --branch [branch]',

--- a/config/default.js
+++ b/config/default.js
@@ -51,11 +51,11 @@ module.exports = {
 				name: 'Sprucebot Relay'
 			}
 		},
-		'react-sprucebot': {
+		'sprucebot-skills-kit': {
 			repo: {
-				name: 'react-sprucebot',
-				path: './react-sprucebot',
-				env: false
+				name: 'workspace.sprucebot-skills-kit',
+				path: './workspace.sprucebot-skills-kit',
+				env: './packages/sprucebot-skills-kit'
 			},
 			pm2: null
 		},
@@ -67,35 +67,11 @@ module.exports = {
 			},
 			pm2: null
 		},
-		'sprucebot-node': {
-			repo: {
-				name: 'sprucebot-node',
-				path: './sprucebot-node',
-				env: false
-			},
-			pm2: null
-		},
 		'teammate-app': {
 			repo: {
 				name: 'sprucebot-teammate-app',
 				path: './teammate-app',
 				env: false
-			},
-			pm2: null
-		},
-		'sprucebot-skills-kit-server': {
-			repo: {
-				name: 'sprucebot-skills-kit-server',
-				path: './sprucebot-skills-kit-server',
-				env: false
-			},
-			pm2: null
-		},
-		'sprucebot-skills-kit': {
-			repo: {
-				name: 'sprucebot-skills-kit',
-				path: './sprucebot-skills-kit',
-				env: './'
 			},
 			pm2: null
 		}


### PR DESCRIPTION
…devs
https://github.com/sprucelabsai/workspace.sprucebot-skills-kit
@sprucelabsai/engineers

## Description 
Clone in the new workspace for platform install

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
To just install the new workspace
`sprucebot platform install ./workspace.sprucebot-skills-kit -p sprucebot-skills-kit`
`cd ./workspace.sprucebot-skills-kit/packages/sprucebot-skills-kit`
`sprucebot remote select`
`sprucebot user login`
`sprucebot skill register`
`cd ../../`
`yarn local`

To install the whole platform as a new developer
`sprucebot platform install`
