### PR TITLE
[SB-1180] clones sprucebot-skills-kit from npm registry

### DIFF
--- a/actions/platform/install.js
+++ b/actions/platform/install.js
@@ -217,7 +217,9 @@ async function prompt(options) {
 	}
 	if (!path.isAbsolute(values.installPath)) {
 		throw new Error(
-			`Woops, I can only install in an absolute installPath. You supplied ${values.installPath}`
+			`Woops, I can only install in an absolute installPath. You supplied ${
+				values.installPath
+			}`
 		)
 	}
 	return values
@@ -238,8 +240,8 @@ async function fetchPlatform(installPath, repoName, gitUser) {
 /**
  * Checks if the supplied commands are available in PATH
  * and makes sure they return status === 0
- * 
- * @param {Array} commands 
+ *
+ * @param {Array} commands
  * @returns {void} Exits if any command returns status >=1
  */
 async function checkDependenciesInstalled(commands) {

--- a/actions/skill/index.js
+++ b/actions/skill/index.js
@@ -74,6 +74,7 @@ function setup(argv) {
 		.description('Create a new skill')
 		.option('-n --name [name]', 'Name of your skill')
 		.option('-s --slug [name]', 'Slug of your skill')
+		.option('-p --pkg [version]', 'npm package version')
 		.action(requireSkill(false, create))
 
 	program

--- a/actions/skill/register.js
+++ b/actions/skill/register.js
@@ -100,7 +100,10 @@ module.exports = async function(commander) {
 	})
 
 	if (hasTunnelAnswer.hasTunnel) {
-		const port = skillUtil.readEnv('PORT')
+		let port = skillUtil.readEnv('PORT')
+		if (!port) {
+			port = skillUtil.writeEnv('PORT', 3006)
+		}
 		log.hint(
 			'\n\nPoint your tunnel to `http://localhost:' +
 				port +
@@ -148,10 +151,12 @@ module.exports = async function(commander) {
 			}
 		)
 		// set env variables
+		skillUtil.writeEnv('NAME', registerResponse.name)
 		skillUtil.writeEnv('ID', registerResponse.id)
-		skillUtil.writeEnv('SLUG', registerResponse.slug)
 		skillUtil.writeEnv('API_KEY', registerResponse.apiKey)
+		skillUtil.writeEnv('SLUG', registerResponse.slug)
 		skillUtil.writeEnv('DESCRIPTION', registerResponse.description)
+		skillUtil.writeEnv('ICON', registerResponse.icon)
 	} catch (err) {
 		log.error("Well that didn't go as I expected 🚨")
 		log.error(err.message)

--- a/actions/user/login.js
+++ b/actions/user/login.js
@@ -24,7 +24,9 @@ module.exports = async function login(phone, command) {
 		)
 		await log.enterToContinue()
 		log.instructions(
-			`You will need to login for each skill you are developing. Use the phone you setup at ${remote.label}.  Once you log in, you'll be able to generate the your skill's ID & API_KEY.`
+			`You will need to login for each skill you are developing. Use the phone you setup at ${
+				remote.label
+			}.  Once you log in, you'll be able to generate the your skill's ID & API_KEY.`
 		)
 
 		log.instructions(
@@ -92,8 +94,9 @@ module.exports = async function login(phone, command) {
 		location = locations[0].Location
 	} else {
 		log.line(
-			`I see you are owner of ${locations.length ===
-				1} location${locations.length === 1 ? '' : 's'}.`
+			`I see you are owner of ${locations.length === 1} location${
+				locations.length === 1 ? '' : 's'
+			}.`
 		)
 
 		const locationAnswer = await inquirer.prompt({
@@ -124,7 +127,9 @@ module.exports = async function login(phone, command) {
 		)
 
 		log.instructions(
-			`Next step is to register your skill so it's available when you visit ${remote.label}.`
+			`Next step is to register your skill so it's available when you visit ${
+				remote.label
+			}.`
 		)
 	}
 

--- a/bin/sprucebot-skill.js
+++ b/bin/sprucebot-skill.js
@@ -2,9 +2,5 @@
 const chalk = require('chalk')
 const assert = require('assert')
 
-try {
-	const platform = require('../actions/skill')
-	module.exports = platform(process.argv)
-} catch (err) {
-	console.log(chalk.bold.red(err.stack))
-}
+const skill = require('../actions/skill')
+module.exports = skill(process.argv)

--- a/config/default.js
+++ b/config/default.js
@@ -9,7 +9,8 @@ module.exports = {
 	TEMP,
 	appname: 'sprucebot',
 	gitUser: 'sprucelabsai',
-	skillsKitRepo: 'https://github.com/sprucelabsai/sprucebot-skills-kit.git',
+	skillKitPackage: 'sprucebot-skills-kit', // npm module name
+	registry: 'https://registry.npmjs.org/',
 	platforms: {
 		api: {
 			repo: {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "node ./bin/sprucebot.js",
-    "lint": "./node_modules/.bin/eslint --fix '**/**/*{.js,.scss}'",
+    "lint": "./node_modules/.bin/eslint '**/**/*{.js}'",
     "test": "jest",
     "precommit": "npm run lint",
     "prepush": "npm run lint && npm run test"
@@ -29,6 +29,7 @@
     "commander": "^2.11.0",
     "config": "^1.26.2",
     "fs-extra": "^5.0.0",
+    "gunzip-maybe": "^1.4.1",
     "hostile": "^1.3.0",
     "ini": "^1.3.4",
     "inquirer": "^5.0.0",
@@ -37,6 +38,7 @@
     "pg": "^7.3.0",
     "request": "^2.83.0",
     "sleep": "^5.1.1",
+    "tar-fs": "^1.16.0",
     "untildify": "^3.0.2",
     "wrap-ansi": "^3.0.1",
     "yeoman-environment": "^2.0.3",

--- a/utils/skill.js
+++ b/utils/skill.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const os = require('os')
 
 exports.isSkill = (cwd = process.cwd()) => {
 	try {
@@ -18,12 +19,17 @@ exports.isSkill = (cwd = process.cwd()) => {
 
 exports.writeEnv = (key, value, env = process.cwd() + '/.env') => {
 	const contents = fs.readFileSync(env).toString()
-	const newContents = contents.replace(
-		new RegExp(`${key}=(.*)`),
-		`${key}=${value}`
-	)
+	const target = new RegExp(`${key}=(.*)`)
+	const newVal = `${key}=${value}`
+	let newContents
+	if (contents.match(target)) {
+		newContents = contents.replace(target, newVal)
+	} else {
+		newContents = `${contents}${os.EOL}${newVal}`
+	}
 
 	fs.writeFileSync(env, newContents)
+	return value
 }
 
 exports.readEnv = (key, env = process.cwd() + '/.env') => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -410,6 +410,12 @@ binaryextensions@2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
 
+bl@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
+  dependencies:
+    readable-stream "^2.0.5"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -475,6 +481,12 @@ browser-resolve@^1.11.2:
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
   dependencies:
     resolve "1.1.7"
+
+browserify-zlib@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
+  dependencies:
+    pako "~0.2.0"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -562,6 +574,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
 ci-info@^1.0.0:
   version "1.1.3"
@@ -928,6 +944,15 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
+duplexify@^3.5.0, duplexify@^3.5.3:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.5.4.tgz#4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4"
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -941,6 +966,12 @@ editions@^1.3.3:
 ejs@^2.3.1:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -1013,8 +1044,8 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^4.8.0:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.0.tgz#9e900efb5506812ac374557034ef6f5c3642fc4c"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -1025,7 +1056,7 @@ eslint@^4.8.0:
     doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.2"
+    espree "^3.5.4"
     esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -1047,6 +1078,7 @@ eslint@^4.8.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
@@ -1054,7 +1086,7 @@ eslint@^4.8.0:
     table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.5.2:
+espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
@@ -1584,6 +1616,17 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+gunzip-maybe@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz#39c72ed89d1b49ba708e18776500488902a52027"
+  dependencies:
+    browserify-zlib "^0.1.4"
+    is-deflate "^1.0.0"
+    is-gzip "^1.0.0"
+    peek-stream "^1.1.0"
+    pumpify "^1.3.3"
+    through2 "^2.0.3"
+
 handlebars@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
@@ -1910,6 +1953,10 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
+is-deflate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-deflate/-/is-deflate-1.0.0.tgz#c862901c3c161fb09dac7cdc7e784f80e98f2f14"
+
 is-descriptor@^0.1.0:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
@@ -1975,6 +2022,10 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-gzip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -2878,8 +2929,8 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@>=2.5.1, nan@^2.3.0:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.9.2.tgz#f564d75f5f8f36a6d9456cca7a6c4fe488ab7866"
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -2991,8 +3042,8 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
 nwmatcher@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.4.tgz#2285631f34a95f0d0395cd900c96ed39b58f346e"
 
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
@@ -3044,7 +3095,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -3139,6 +3190,10 @@ packet-reader@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.3.1.tgz#cd62e60af8d7fea8a705ec4ff990871c46871f27"
 
+pako@~0.2.0:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -3220,6 +3275,13 @@ path-type@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
   dependencies:
     pify "^3.0.0"
+
+peek-stream@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.2.tgz#97eb76365bcfd8c89e287f55c8b69d4c3e9bcc52"
+  dependencies:
+    duplexify "^3.5.0"
+    through2 "^2.0.3"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -3362,6 +3424,28 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.4.0.tgz#80b7c5df7e24153d03f0e7ac8a05a5d068bd07fb"
+  dependencies:
+    duplexify "^3.5.3"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3446,7 +3530,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.5:
+readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
@@ -3486,6 +3570,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexpp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.0.1.tgz#d857c3a741dce075c2848dcb019a0a975b190d43"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -3974,6 +4062,10 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+stream-shift@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -4086,6 +4178,15 @@ table@4.0.2:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+tar-fs@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.0.tgz#e877a25acbcc51d8c790da1c57c9cf439817b896"
+  dependencies:
+    chownr "^1.0.1"
+    mkdirp "^0.5.1"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
 tar-pack@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -4098,6 +4199,15 @@ tar-pack@^3.4.0:
     rimraf "^2.5.1"
     tar "^2.2.1"
     uid-number "^0.0.6"
+
+tar-stream@^1.1.2:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.5.tgz#5cad84779f45c83b1f2508d96b09d88c7218af55"
+  dependencies:
+    bl "^1.0.0"
+    end-of-stream "^1.0.0"
+    readable-stream "^2.0.0"
+    xtend "^4.0.0"
 
 tar@^2.2.1:
   version "2.2.1"
@@ -4133,7 +4243,7 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-through2@^2.0.0:
+through2@^2.0.0, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:


### PR DESCRIPTION
[SB-1180](https://jira.sprucelabs.ai/jira/browse/SB-1180)

@sprucelabsai/engineers

## Description 
We can no longer clone the sprucebot-skills-kit since it's in a multi-package repo now.
Instead we only download "published" versions from the npm registry.

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
* `sprucebot skill create`
* Select desired version from prompt
* Notice the skill downloads
* `sprucebot remote set`
* `sprucebot skill register`
* `yarn && yarn build && yarn start`
