### PR TITLE
[SB-773] Check for https on ngrok tunnel is no longer case sensitive.

### DIFF
--- a/actions/skill/register.js
+++ b/actions/skill/register.js
@@ -127,8 +127,8 @@ module.exports = async function(commander) {
 					'Oops!  I think you forgot to make your tunnel secure.  Try again and make sure it has https!'
 				)
 			} else {
-				skillUtil.writeEnv('SERVER_HOST', tunnelAnswer.url.toLowerCase())
-				skillUtil.writeEnv('INTERFACE_HOST', tunnelAnswer.url.toLowerCase())
+				skillUtil.writeEnv('SERVER_HOST', tunnelAnswer.url)
+				skillUtil.writeEnv('INTERFACE_HOST', tunnelAnswer.url)
 			}
 		} while (unsecureTunnel)
 	}

--- a/actions/skill/register.js
+++ b/actions/skill/register.js
@@ -120,15 +120,15 @@ module.exports = async function(commander) {
 				required: true
 			})
 
-			unsecureTunnel = !tunnelAnswer.url.includes('https://')
+			unsecureTunnel = !tunnelAnswer.url.toLowerCase().includes('https://')
 
 			if (unsecureTunnel) {
 				log.instructions(
 					'Oops!  I think you forgot to make your tunnel secure.  Try again and make sure it has https!'
 				)
 			} else {
-				skillUtil.writeEnv('SERVER_HOST', tunnelAnswer.url)
-				skillUtil.writeEnv('INTERFACE_HOST', tunnelAnswer.url)
+				skillUtil.writeEnv('SERVER_HOST', tunnelAnswer.url.toLowerCase())
+				skillUtil.writeEnv('INTERFACE_HOST', tunnelAnswer.url.toLowerCase())
 			}
 		} while (unsecureTunnel)
 	}


### PR DESCRIPTION
[SB-773](https://jira.sprucelabs.ai/jira/browse/SB-773)

@sprucelabsai/engineers

## Description 
Check for https on ngrok tunnel is no longer case sensitive.
Any capitol letters in it will automatically be made lowercase in the .env file.

## Type
- [ ] Feature
- [ ] Bug
- [x] Tech debt

## Steps to Test or Reproduce
Try registering a new skill and add something like "HTTPS://travIS.NGROK.io" to it.  Notice it is accepted and the skill registers.  Then check the .env file.  It is lowercase in the file and would look like https://travis.ngrok.io.
