### PR TITLE
fix(SB-1135): install workspace dependencies after copying package

### DIFF
--- a/actions/platform/install.js
+++ b/actions/platform/install.js
@@ -27,6 +27,12 @@ module.exports = async function init(startingPath = false, options = {}) {
 				args: ['-v'],
 				message:
 					'I work better with friends! 🤖. Please install Docker. https://docs.docker.com/docker-for-mac/install/'
+			},
+			{
+				exectable: 'yarn',
+				args: ['-v'],
+				message:
+					'I work better with friends! 🤖. Please install yarn. https://yarnpkg.com/en/docs/install'
 			}
 		])
 	}
@@ -89,7 +95,7 @@ module.exports = async function init(startingPath = false, options = {}) {
 			if (!yarnInstall(platformPath)) {
 				console.log(
 					chalk.bold.red(
-						`Crap, I had trouble with ${'`yarn install --ignore-engines`'} in ${platformPath}. See error above for more deets.`
+						`Crap, I had trouble with ${'`yarn install`'} in ${platformPath}. See error above for more deets.`
 					)
 				)
 				return // what do we do here?
@@ -154,26 +160,17 @@ module.exports = async function init(startingPath = false, options = {}) {
 		)
 		const devServicesPath = config.get('platforms.dev.repo.path')
 
+		const workspaceFrom = path.resolve(
+			promptValues.installPath,
+			`${devServicesPath}/workspace`
+		)
+		const workspaceTo = path.resolve(promptValues.installPath)
+		await copyFile(workspaceFrom, workspaceTo)
+
 		yarnInstall(promptValues.installPath)
 
-		const ecoFrom = path.resolve(
-			promptValues.installPath,
-			`${devServicesPath}/ecosystem.config.js`
-		)
-		const ecoTo = path.resolve(
-			promptValues.installPath,
-			'./ecosystem.config.js'
-		)
-		await copyFile(ecoFrom, ecoTo)
-
-		const packageFrom = path.resolve(
-			promptValues.installPath,
-			`${devServicesPath}/package.json`
-		)
-		const packageTo = path.resolve(promptValues.installPath, './package.json')
-		await copyFile(packageFrom, packageTo)
-
 		console.log(chalk.green('Checking hosts to determine next step.'))
+
 		let hasHostFile = await checkHostile(promptValues)
 
 		if (!hasHostFile) {
@@ -315,8 +312,7 @@ function yarnInstall(cwd) {
 		env: process.env
 	})
 
-	// HOLY SHIT --ignore-engines!!! TODO: honor .nvmrc
-	const cmd = childProcess.spawnSync('yarn', ['install', '--ignore-engines'], {
+	const cmd = childProcess.spawnSync('yarn', ['install'], {
 		cwd,
 		stdio: 'inherit',
 		env: process.env

--- a/utils/Git.js
+++ b/utils/Git.js
@@ -9,10 +9,11 @@ function spawnGit(cwd, args, options) {
 	})
 
 	if (cmd.status !== 0) {
-		cmd.stderr &&
-			cmd.stderr.toString &&
-			console.error(chalk.yellow(cmd.stderr.toString()))
-		return new Error(cmd.stderr.toString())
+		const message =
+			(cmd.stderr && cmd.stderr.toString && cmd.stderr.toString()) ||
+			'Unknown Git Error'
+		console.error(chalk.yellow(message))
+		return new Error(message)
 	}
 
 	return Buffer.isBuffer(cmd.stdout) ? cmd.stdout.toString() : ''


### PR DESCRIPTION
[SB-1135](https://jira.sprucelabs.ai/jira/browse/SB-1135)

@sprucelabsai/engineers

## Description 
The workspace install step was happening before we copied the package.json from dev-serivces/workspace

## Type
- [ ] Feature
- [x] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Make sure sprucelabsai/sprucebot-dev-services#8 and sprucelabsai/workspace.sprucebot-skills-kit#30 get merged first
`sprucebot platform install`