### PR TITLE
SB-1111 - adds sprucebot skill update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,19 @@ yarn global add sprucebot-cli
 This is where the magic happens!
 
 * `sprucebot skill create`
-  * Downloads the [Skills Kit](https://github.com/sprucelabsai/sprucebot-skills-kit) and helps you get your new skill setup
+  * Downloads the [Skills Kit](https://www.npmjs.com/package/sprucebot-skills-kit) and helps you get your new skill setup
   * All subsequent commands require you to be in the skill's directory
-* `sprucebot remote set [prod|alpha|stage|qa|dev|alpha]
+* `sprucebot remote set [prod|alpha|stage|qa|dev|alpha]`
   * You probably only have access to `prod`
   * If you wish test skills at `alpha` locations, eg [Spruce](https://vimeo.com/214239239), email `scientists@sprucelabs.ai`
   * If you wish to get early access to features on `stage`... you guessed it
 * `sprucebot skill register`
   * Registers your skill with `remote`
+* `sprucebot skill update`
+  * Updates your skill from `package.json#version` to `sprucebot-skills-kit@version`
+  * Requires a clean working directory and git repo
+  * To see what changed, use `git status`
+  * After resolving any conflicts run `yarn install && yarn test`
 * `sprucebot skill unregister` -*COMING SOON*-
   * Takes your skill entirely off remote
   * It will be uninstalled from all locations that had it

--- a/actions/skill/index.js
+++ b/actions/skill/index.js
@@ -3,6 +3,7 @@ const { Command } = require('commander')
 
 const create = require('./create')
 const register = require('./register')
+const update = require('./update')
 const assert = require('assert')
 const configUtil = require('../../utils/config')
 const skillUtil = require('../../utils/skill')
@@ -76,6 +77,14 @@ function setup(argv) {
 		.option('-s --slug [name]', 'Slug of your skill')
 		.option('-p --pkg [version]', 'npm package version')
 		.action(requireSkill(false, create))
+
+	program
+		.command('update')
+		.description(
+			'Apply a git patch to update skill from package.json to a newer verion'
+		)
+		.option('-p --pkg [version]', 'npm package version')
+		.action(requireSkill(false, update))
 
 	program
 		.command('register')

--- a/actions/skill/update.js
+++ b/actions/skill/update.js
@@ -1,0 +1,151 @@
+const debug = require('debug')('sprucebot-cli')
+const os = require('os')
+const fs = require('fs-extra')
+const path = require('path')
+const config = require('config')
+const chalk = require('chalk')
+const execa = require('execa')
+const inquirer = require('inquirer')
+const skillUtil = require('../../utils/skill')
+const log = require('../../utils/log')
+const Git = require('../../utils/Git')
+const {
+	pkgVersions,
+	getLatestVersion,
+	extractPackage
+} = require('../../utils/Npm')
+
+const PKG_NAME = config.get('skillKitPackage')
+const TEMP = path.join(os.tmpdir(), new Date().getTime().toString())
+
+module.exports = async function update(commander) {
+	if (!skillUtil.isSkill()) {
+		log.error(
+			chalk.bold.red(
+				'You are not in a skill. Try `sprucebot skill create` first 😂'
+			)
+		)
+		return
+	}
+
+	try {
+		if (!Git.isWorkingClean(process.cwd())) {
+			log.error('Your working directory must be clean to update')
+			log.hint('Try `git stash save` or `git commit`')
+			return 1
+		}
+
+		const skillPkg = skillUtil.getPkg()
+		const versions = await pkgVersions(PKG_NAME)
+		if (versions.indexOf(skillPkg.version) === -1) {
+			log.error(
+				`${PKG_NAME}@${skillPkg.version} does not exist in the npm registry`
+			)
+			log.hint(
+				`If this is your first time updating the skill, you are probably on a very old version. Change your declared version to 0.3.0, and then try updating again`
+			)
+			return 1
+		}
+
+		let version = commander.pkg
+		if (!version) {
+			const versionAnswer = await inquirer.prompt({
+				type: 'list',
+				name: 'version',
+				message: `Select the version to use`,
+				choices: ['latest'].concat(versions.reverse())
+			})
+
+			version = versionAnswer.version
+		}
+
+		if (version === 'latest') {
+			version = await getLatestVersion(PKG_NAME)
+		}
+
+		log.hint(
+			`Updating ${skillPkg.name}@${
+				skillPkg.version
+			} to ${PKG_NAME}@${version} 👀`
+		)
+
+		const confirmAnswer = await inquirer.prompt({
+			type: 'confirm',
+			name: 'confirm',
+			message: 'Are you sure you want to update?',
+			default: false
+		})
+
+		if (!confirmAnswer.confirm) {
+			// Bail due to user input!
+			return 1
+		}
+
+		await setup()
+
+		debug(`Attempting to clone old version to ${skillPkg.version} ${TEMP}`)
+		await extractPackage(PKG_NAME, skillPkg.version, process.cwd())
+
+		await execa.shell('git add .')
+		await execa.shell('git commit -m "Old Version" --no-verify --allow-empty')
+
+		debug(`Attempting to clone new version to ${version} ${TEMP}`)
+		await extractPackage(PKG_NAME, version, process.cwd())
+
+		await execa.shell('git add .')
+		await execa.shell('git commit -m "Newer Version" --no-verify')
+
+		const patchPath = path.join(TEMP, 'changes.patch')
+		await execa
+			.shell('git diff --binary --no-color HEAD~1 HEAD')
+			.stdout.pipe(fs.createWriteStream(patchPath))
+
+		await execa.shell('git reset --hard HEAD~2')
+
+		try {
+			await execa.shell(`git apply --3way ${patchPath}`)
+		} catch (cmd) {
+			log.line(cmd.stderr)
+			log.error(
+				'Successfully applied the patch, but there may be conflicts to resolve 🤔'
+			)
+		} finally {
+			log.success('Finished updating the skill')
+			log.hint('To see what changed, use `git status`')
+			log.hint('After resolving any conflicts run `yarn install && yarn test`')
+		}
+	} catch (err) {
+		log.error('Error while running update')
+		console.error(err)
+	} finally {
+		cleanup()
+	}
+
+	return 0
+}
+
+async function setup() {
+	fs.removeSync(TEMP)
+	fs.mkdirpSync(TEMP)
+
+	process.env.GIT_DIR = path.resolve(TEMP, '.git')
+	process.env.GIT_WORK_TREE = '.'
+
+	await execa.shell('git init')
+
+	try {
+		const ignoreContents = fs.readFileSync('.gitignore', 'utf8')
+		fs.appendFileSync(
+			path.resolve(TEMP, process.env.GIT_DIR, 'info/exclude'),
+			ignoreContents
+		)
+	} catch (e) {
+		debug("Couldn't find a .gitignore file to append")
+	}
+
+	await execa.shell('git add .')
+
+	await execa.shell('git commit -m "Init Checkpoint" --no-verify')
+}
+
+function cleanup() {}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chalk": "^2.1.0",
     "commander": "^2.11.0",
     "config": "^1.26.2",
+    "execa": "^0.10.0",
     "fs-extra": "^5.0.0",
     "gunzip-maybe": "^1.4.1",
     "hostile": "^1.3.0",

--- a/utils/Git.js
+++ b/utils/Git.js
@@ -29,6 +29,12 @@ function checkoutBranch(repoPath, branch) {
 	return spawnGit(repoPath, ['checkout', branch])
 }
 
+module.exports.isWorkingClean = isWorkingClean
+function isWorkingClean(repoPath) {
+	const output = spawnGit(repoPath, ['status', '--porcelain'])
+	return !output
+}
+
 module.exports.Remote = {
 	delete: deleteRemote,
 	create: createRemote

--- a/utils/Npm.js
+++ b/utils/Npm.js
@@ -1,0 +1,67 @@
+const execa = require('execa')
+const path = require('path')
+const config = require('config')
+const request = require('request')
+const tar = require('tar-fs')
+const gunzip = require('gunzip-maybe')
+const debug = require('debug')('sprucebot-cli')
+const log = require('./log')
+
+module.exports = {
+	extractPackage,
+	pkgVersions
+}
+
+async function extractPackage(pkg, version, to) {
+	if (version === 'latest') {
+		const cmd = await execa('npm', ['view', pkg, 'version'])
+		version = cmd.stdout
+		log.line(`Determined the latest ${pkg} version is ${version}`)
+	}
+	const pkgUrl = `${config.get('registry')}${pkg}/-/${pkg}-${version}.tgz`
+	debug(pkgUrl)
+	// Wait for package to download and unpack into `to` directory
+	await new Promise((resolve, reject) => {
+		request
+			.get(pkgUrl)
+			.on('response', res => {
+				res.statusCode !== 200 && reject(res)
+			})
+			.on('error', res => reject(res))
+			.pipe(gunzip())
+			.pipe(
+				tar.extract(to, {
+					finish: resolve,
+					map: header => {
+						// Replace leading `/package/` folder
+						header.name = header.name.replace(/^package\//, '')
+						return header
+					},
+					filter: header => {
+						// Remove the base package folder from being created
+						return path.join(to, 'package') === header
+					}
+				})
+			)
+	})
+
+	return true
+}
+
+async function pkgVersions(pkg) {
+	const cmd = await execa('npm', ['view', pkg, 'versions'], {
+		env: process.env
+	})
+
+	if (cmd.code !== 0) {
+		
+			console.error(chalk.yellow(cmd.stderr))
+		throw new Error(
+			cmd.stderr || 'Unknown spawn error'
+		)
+	}
+
+	// string containt brackets "[ '1.0.0', '1.0.1' ]"
+	const output = cmd.stdout || '[]'
+	return JSON.parse(output.replace(/'/g, '"')) // Remove leading and trailing brackets from string and transform to array
+}

--- a/utils/skill.js
+++ b/utils/skill.js
@@ -1,9 +1,11 @@
 const fs = require('fs')
 const os = require('os')
+const path = require('path')
+const debug = require('debug')('sprucebot-cli')
 
 exports.isSkill = (cwd = process.cwd()) => {
 	try {
-		const pkg = require(`${cwd}/package.json`)
+		const pkg = getPkg(cwd)
 		if (
 			!pkg ||
 			!pkg.dependencies ||
@@ -13,6 +15,7 @@ exports.isSkill = (cwd = process.cwd()) => {
 		}
 		return true
 	} catch (err) {
+		debug(err)
 		return false
 	}
 }
@@ -49,3 +52,9 @@ exports.skill = (env = process.cwd() + '/.env') => {
 		slug: this.readEnv('SLUG')
 	}
 }
+
+function getPkg(dir = process.cwd()) {
+	return require(path.join(dir, 'package.json'))
+}
+
+exports.getPkg = getPkg

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,6 +776,16 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1126,6 +1136,18 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -2957,6 +2979,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 nise@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/nise/-/nise-1.3.1.tgz#ae0008e270f1841602ee34af302037fa3d2fd3a8"
@@ -3242,7 +3268,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -3804,7 +3830,7 @@ scoped-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION
[SB-1111](https://jira.sprucelabs.ai/jira/browse/SB-1111)
[SB-1166](https://jira.sprucelabs.ai/jira/browse/SB-1166)

@sprucelabsai/engineers

## Description 
Adds `sprucebot skill update`
Ran the update against a couple of our real skills so far:
https://github.com/sprucelabsai/sprucebot-skill-awards/pull/30
https://github.com/sprucelabsai/sprucebot-skill-check-in/pull/26

## Type
- [x] Feature
- [ ] Bug
- [ ] Tech debt

## Steps to Test or Reproduce
Create a new skill at an older version. `sprucebot skill create --pkg 1.0.0`
`cd skill && git init && git commit -m "initial commit"`
`sprucebot skill update` and choose a version to update to
Review the files change with `git status`
