### PR TITLE
Fix choosing "latest"

### DIFF
--- a/utils/Npm.js
+++ b/utils/Npm.js
@@ -20,7 +20,7 @@ async function getLatestVersion(pkg) {
 
 async function extractPackage(pkg, version, to = proces.cwd()) {
 	if (version === 'latest') {
-		const version = getLatestVersion(pkg)
+		version = await getLatestVersion(pkg)
 		log.line(`Determined the latest ${pkg} version is ${version}`)
 	}
 	const pkgUrl = `${config.get('registry')}${pkg}/-/${pkg}-${version}.tgz`


### PR DESCRIPTION
## Description 

* Fixes choosing "latest" causing error.  The get version was not being awaited and `version` was being redefined in the if block

## Type
- [ ] Feature
- [X] Bug
- [ ] Tech debt
